### PR TITLE
docs: fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ g -group
 
 ```bash
 g -size 
-g -size -recusive-size # show size of dir recursively
+g -size -recursive-size # show size of dir recursively
 ```
 
 显示所有文件，包括隐藏文件

--- a/README_EN.md
+++ b/README_EN.md
@@ -158,7 +158,7 @@ with size
 
 ```bash
 g -size 
-g -size -recusive-size # show size of dir recursively
+g -size -recursive-size # show size of dir recursively
 ```
 
 show all files, including hidden files

--- a/app/display.go
+++ b/app/display.go
@@ -58,7 +58,7 @@ var displayFlag = []cli.Flag{
 			case "24bit", "truecolor", "true-color", "24-bit", "16m":
 				theme.ColorLevel = theme.TrueColor
 			default:
-				return fmt.Errorf("unkown color option:%s", s)
+				return fmt.Errorf("unknown color option:%s", s)
 			}
 			return nil
 		},
@@ -370,7 +370,7 @@ var displayFlag = []cli.Flag{
 					p = display.NewTreePrinter()
 				}
 			default:
-				return fmt.Errorf("unkown format option:%s", s)
+				return fmt.Errorf("unknown format option:%s", s)
 			}
 			return nil
 		},


### PR DESCRIPTION
found via `typos --format brief`