### PR TITLE
ci: Pinning golangci-lint action to a full length commit SHA

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.24.0
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837
         with:
           install-mode: "binary"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.24.0
-      - uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837
+      - uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
         with:
           install-mode: "binary"


### PR DESCRIPTION
- **ci: Pinning golangci-lint action to a full length commit SHA**
- **add comment**
