### PR TITLE
docs: fix typos again

### DIFF
--- a/internal/git/git_commit.go
+++ b/internal/git/git_commit.go
@@ -13,15 +13,15 @@ import (
 type CommitInfo struct {
 	Hash string `json:"h"`
 
-	Comitter     string `json:"c"`
-	ComitterDate string `json:"cd"`
+	Committer     string `json:"c"`
+	CommitterDate string `json:"cd"`
 
 	Author     string `json:"a"`
 	AuthorDate string `json:"ad"`
 }
 
-func (c CommitInfo) GetCommiterDateInFormat(format string) string {
-	t, err := time.Parse(time.RFC3339, c.ComitterDate)
+func (c CommitInfo) GetCommitterDateInFormat(format string) string {
+	t, err := time.Parse(time.RFC3339, c.CommitterDate)
 	if err != nil {
 		return ""
 	}

--- a/justfile
+++ b/justfile
@@ -292,7 +292,7 @@ newminor:
 newmajor:
     git add -u && git commit -m ":bookmark: new major version"
 
-boostrap:
+bootstrap:
     sh script/install_dev_requirement.sh
 
 all: precheck gendocs test check clean genrelease release


### PR DESCRIPTION
Found via `codespell -L goup,kno,hda`