### PR TITLE
fix(lint): Fix remaining lint violations across benchmarks, printers, and content helpers

### DIFF
--- a/internal/cli/adaptive_bench_test.go
+++ b/internal/cli/adaptive_bench_test.go
@@ -11,7 +11,9 @@ import (
 // setupAdaptiveTestDir creates test directories of different sizes
 func setupAdaptiveTestDir(tb testing.TB, dirName string, numFiles int) string {
 	testDir := filepath.Join(os.TempDir(), dirName)
-	os.RemoveAll(testDir)
+	if err := os.RemoveAll(testDir); err != nil {
+		tb.Fatalf("failed to clean test directory: %v", err)
+	}
 	if err := os.MkdirAll(testDir, 0o755); err != nil {
 		tb.Fatalf("failed to create test directory: %v", err)
 	}
@@ -25,7 +27,9 @@ func setupAdaptiveTestDir(tb testing.TB, dirName string, numFiles int) string {
 		if _, err := f.WriteString("test content"); err != nil {
 			tb.Fatalf("failed to write test content: %v", err)
 		}
-		f.Close()
+		if err := f.Close(); err != nil {
+			tb.Fatalf("failed to close test file: %v", err)
+		}
 	}
 
 	return testDir
@@ -34,7 +38,9 @@ func setupAdaptiveTestDir(tb testing.TB, dirName string, numFiles int) string {
 // BenchmarkAdaptiveStrategy_SmallDir tests adaptive strategy on small directories
 func BenchmarkAdaptiveStrategy_SmallDir(b *testing.B) {
 	testDir := setupAdaptiveTestDir(b, "adaptive_small", 25) // Below 50-file threshold
-	defer os.RemoveAll(testDir)
+	defer func() {
+		_ = os.RemoveAll(testDir)
+	}()
 
 	b.ResetTimer()
 	b.ReportAllocs()
@@ -50,7 +56,9 @@ func BenchmarkAdaptiveStrategy_SmallDir(b *testing.B) {
 // BenchmarkAdaptiveStrategy_LargeDir tests adaptive strategy on large directories
 func BenchmarkAdaptiveStrategy_LargeDir(b *testing.B) {
 	testDir := setupAdaptiveTestDir(b, "adaptive_large", 200) // Above 50-file threshold
-	defer os.RemoveAll(testDir)
+	defer func() {
+		_ = os.RemoveAll(testDir)
+	}()
 
 	b.ResetTimer()
 	b.ReportAllocs()
@@ -66,7 +74,9 @@ func BenchmarkAdaptiveStrategy_LargeDir(b *testing.B) {
 // BenchmarkAdaptiveStrategy_JSON tests adaptive strategy with JSON output
 func BenchmarkAdaptiveStrategy_JSON(b *testing.B) {
 	testDir := setupAdaptiveTestDir(b, "adaptive_json", 200) // Large dir but JSON format
-	defer os.RemoveAll(testDir)
+	defer func() {
+		_ = os.RemoveAll(testDir)
+	}()
 
 	b.ResetTimer()
 	b.ReportAllocs()
@@ -85,7 +95,9 @@ func TestAdaptiveStrategy_DecisionLogic(t *testing.T) {
 
 	// Test small directory - should use traditional
 	smallDir := setupAdaptiveTestDir(t, "test_small", 25)
-	defer os.RemoveAll(smallDir)
+	defer func() {
+		_ = os.RemoveAll(smallDir)
+	}()
 
 	// Debug info
 	estimatedSize := strategy.EstimateDirectorySize(smallDir)
@@ -98,7 +110,9 @@ func TestAdaptiveStrategy_DecisionLogic(t *testing.T) {
 
 	// Test large directory - should use batch
 	largeDir := setupAdaptiveTestDir(t, "test_large", 100)
-	defer os.RemoveAll(largeDir)
+	defer func() {
+		_ = os.RemoveAll(largeDir)
+	}()
 
 	estimatedSize = strategy.EstimateDirectorySize(largeDir)
 	t.Logf("Large dir estimated size: %d, threshold: 50", estimatedSize)

--- a/internal/cli/dive_bench_test.go
+++ b/internal/cli/dive_bench_test.go
@@ -13,7 +13,9 @@ import (
 // setupBenchmarkDir creates test directory structure for benchmarking
 func setupBenchmarkDir(b *testing.B, dirName string, numDirs, numFiles int) string {
 	testDir := filepath.Join(os.TempDir(), dirName)
-	os.RemoveAll(testDir)
+	if err := os.RemoveAll(testDir); err != nil {
+		b.Fatalf("failed to clean test directory: %v", err)
+	}
 	if err := os.MkdirAll(testDir, 0o755); err != nil {
 		b.Fatalf("failed to create test directory: %v", err)
 	}
@@ -26,8 +28,13 @@ func setupBenchmarkDir(b *testing.B, dirName string, numDirs, numFiles int) stri
 
 		for j := range numFiles {
 			fileName := filepath.Join(subDir, "file"+string(rune('0'+j%10))+".txt")
-			f, _ := os.Create(fileName)
-			f.Close()
+			f, err := os.Create(fileName)
+			if err != nil {
+				b.Fatalf("failed to create test file: %v", err)
+			}
+			if err := f.Close(); err != nil {
+				b.Fatalf("failed to close test file: %v", err)
+			}
 		}
 	}
 
@@ -37,7 +44,9 @@ func setupBenchmarkDir(b *testing.B, dirName string, numDirs, numFiles int) stri
 // BenchmarkDive_Original tests the performance of the original dive function
 func BenchmarkDive_Original(b *testing.B) {
 	testDir := setupBenchmarkDir(b, "bench_original", 10, 50)
-	defer os.RemoveAll(testDir)
+	defer func() {
+		_ = os.RemoveAll(testDir)
+	}()
 
 	b.ResetTimer()
 	b.ReportAllocs()
@@ -55,7 +64,9 @@ func BenchmarkDive_Original(b *testing.B) {
 // BenchmarkDive_Optimized tests the performance of the optimized dive function
 func BenchmarkDive_Optimized(b *testing.B) {
 	testDir := setupBenchmarkDir(b, "bench_optimized", 10, 50)
-	defer os.RemoveAll(testDir)
+	defer func() {
+		_ = os.RemoveAll(testDir)
+	}()
 
 	b.ResetTimer()
 	b.ReportAllocs()
@@ -73,7 +84,9 @@ func BenchmarkDive_Optimized(b *testing.B) {
 // BenchmarkFileInfoBatch compares traditional vs batched file info retrieval
 func BenchmarkFileInfoBatch(b *testing.B) {
 	testDir := setupBenchmarkDir(b, "bench_batch", 1, 100)
-	defer os.RemoveAll(testDir)
+	defer func() {
+		_ = os.RemoveAll(testDir)
+	}()
 
 	b.Run("Traditional", func(b *testing.B) {
 		b.ReportAllocs()

--- a/internal/cli/index.go
+++ b/internal/cli/index.go
@@ -49,11 +49,7 @@ var indexFlags = []cli.Flag{
 		Category: "INDEX",
 		Action: func(context *cli.Context, i []string) error {
 			var errSum error = nil
-
-			beautification := true
-			if context.Bool("np") { // --no-path-transform
-				beautification = false
-			}
+			beautification := !context.Bool("np") // --no-path-transform
 
 			for _, s := range i {
 				if beautification {

--- a/internal/content/charset.go
+++ b/internal/content/charset.go
@@ -75,7 +75,9 @@ func readFileContent(path string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	content := make([]byte, 1024*1024)
 	_, err = file.Read(content)

--- a/internal/content/duplicate.go
+++ b/internal/content/duplicate.go
@@ -171,7 +171,9 @@ func readCrucialBytes(filePath string, fileSize int64) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	firstBytes := make([]byte, thresholdFileSize/2)
 	_, fErr := file.ReadAt(firstBytes, 0)

--- a/internal/content/size.go
+++ b/internal/content/size.go
@@ -239,11 +239,12 @@ func (s *SizeEnabler) Size2String(b int64) (string, SizeUnit) {
 		}
 		for i := Byte; i <= maxUnit; i *= gap {
 			if v < float64(gap) {
-				if i == Byte {
+				switch i {
+				case Byte:
 					res = strconv.FormatInt(int64(v), 10)
-				} else if i == Bit {
+				case Bit:
 					res = strconv.FormatInt(int64(v*8), 10)
-				} else {
+				default:
 					res = strconv.FormatFloat(v, 'f', 1, 64)
 				}
 				if res == "0" || res == "0.0" {

--- a/internal/content/sum.go
+++ b/internal/content/sum.go
@@ -52,7 +52,9 @@ func (s SumEnabler) EnableSum(renderer *render.Renderer, sumTypes ...SumType) []
 					return "", string(sumType)
 				}
 				info.Cache["content"] = content
-				defer file.Close()
+				defer func() {
+					_ = file.Close()
+				}()
 			}
 
 			var hashed hash.Hash

--- a/internal/display/printer.go
+++ b/internal/display/printer.go
@@ -124,7 +124,9 @@ func (b *Byline) Print(i ...*item.FileInfo) {
 	if !b.disableBefore {
 		fire(b.BeforePrint, b, i...)
 	}
-	defer b.Flush()
+	defer func() {
+		_ = b.Flush()
+	}()
 	for _, v := range i {
 		_, _ = b.WriteString(v.OrderedContent(" "))
 		_ = b.WriteByte('\n') // byline means a new line :)
@@ -152,7 +154,9 @@ func (f *FitTerminal) Print(i ...*item.FileInfo) {
 	if !f.disableBefore {
 		fire(f.BeforePrint, f, i...)
 	}
-	defer f.Flush()
+	defer func() {
+		_ = f.Flush()
+	}()
 	s := make([]string, 0, len(i))
 	for _, v := range i {
 		s = append(s, v.OrderedContent(" "))
@@ -322,7 +326,9 @@ func (c *CommaPrint) Print(items ...*item.FileInfo) {
 	if !c.disableBefore {
 		fire(c.BeforePrint, c, items...)
 	}
-	defer c.Flush()
+	defer func() {
+		_ = c.Flush()
+	}()
 	s := make([]string, 0, len(items))
 	for i, v := range items {
 		if i != len(items)-1 {
@@ -353,7 +359,9 @@ func (a *Across) Print(items ...*item.FileInfo) {
 	if !a.disableBefore {
 		fire(a.BeforePrint, a, items...)
 	}
-	defer a.Flush()
+	defer func() {
+		_ = a.Flush()
+	}()
 	s := make([]string, 0, len(items))
 	for _, v := range items {
 		s = append(s, v.OrderedContent(" "))
@@ -365,7 +373,9 @@ func (a *Across) Print(items ...*item.FileInfo) {
 }
 
 func (a *Across) printRowWithNoSpace(strs []string) {
-	defer a.Flush()
+	defer func() {
+		_ = a.Flush()
+	}()
 	width := getTermWidth() - 5
 
 	maxLength := 0
@@ -456,7 +466,9 @@ func (z *Zero) Print(items ...*item.FileInfo) {
 	if !z.disableBefore {
 		fire(z.BeforePrint, z, items...)
 	}
-	defer z.Flush()
+	defer func() {
+		_ = z.Flush()
+	}()
 	for _, v := range items {
 		_, _ = z.WriteString(v.OrderedContent(" "))
 	}
@@ -489,7 +501,9 @@ func (j *JsonPrinter) Print(items ...*item.FileInfo) {
 	if !j.disableBefore {
 		fire(j.BeforePrint, j, items...)
 	}
-	defer j.Flush()
+	defer func() {
+		_ = j.Flush()
+	}()
 
 	list := make([]*orderedmap.OrderedMap[string, string], 0, len(items))
 	for _, v := range items {
@@ -591,7 +605,9 @@ func (t *TablePrinter) PrintBase(fn func() string, s ...*item.FileInfo) {
 	if !t.disableBefore {
 		fire(t.BeforePrint, t, s...)
 	}
-	defer t.Flush()
+	defer func() {
+		_ = t.Flush()
+	}()
 	t.w.ResetRows()
 	t.setTB(s...)
 	if len(t.header) != 0 {
@@ -706,10 +722,12 @@ func NewTreePrinter() *TreePrinter {
 }
 
 func (t *TreePrinter) Print(s ...*item.FileInfo) {
-	if !t.hook.disableBefore {
+	if !t.disableBefore {
 		fire(t.BeforePrint, t, s...)
 	}
-	defer t.Flush()
+	defer func() {
+		_ = t.Flush()
+	}()
 
 	// split by full path
 	// the item sharing the same dir will be grouped together
@@ -797,7 +815,7 @@ func (t *TreePrinter) Print(s ...*item.FileInfo) {
 	}
 
 	printTree(buildTree.Root, true, true)
-	if !t.hook.disableAfter {
+	if !t.disableAfter {
 		fire(t.AfterPrint, t, s...)
 	}
 }

--- a/internal/osbased/flags_darwin.go
+++ b/internal/osbased/flags_darwin.go
@@ -38,7 +38,9 @@ func getFlags(filename string) uint32 {
 	if err != nil {
 		return 0
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	fileInfo, err := file.Stat()
 	if err != nil {

--- a/man/man.go
+++ b/man/man.go
@@ -14,7 +14,9 @@ func GenMan() {
 	s, _ := cli.G.ToMan()
 	// compress to gzip
 	manGz := gzip.NewWriter(man)
-	defer manGz.Close()
+	defer func() {
+		_ = manGz.Close()
+	}()
 	_, _ = manGz.Write([]byte(s))
 	_ = manGz.Flush()
 }


### PR DESCRIPTION
## Summary
- Fix `errcheck` violations by handling or explicitly ignoring `Close`, `Flush`, and `RemoveAll` errors
- Clean up small `staticcheck` findings in index, size formatting, and printer code
- Keep behavior unchanged while making the codebase pass the stricter lint configuration

## Testing
- `go test ./...`
- `golangci-lint run`