### PR TITLE
ci: force Pages workflow actions to Node 24

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,6 +19,9 @@ concurrency:
   group: pages
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- switch GitHub Pages repository setting to workflow-based deployment instead of legacy `master/docs`
- keep Pages deploy healthy by forcing JavaScript-based actions to run on Node 24 in `pages.yml`
- validate the Pages pipeline by re-running workflow dispatch deployments successfully

## Test plan
- [x] Run `npm ci && npm run build` in `web`
- [x] Trigger `pages.yml` manually and verify `build` and `deploy` jobs succeed
- [x] Verify site is reachable at `https://equationzhao.github.io/g/`

Made with [Cursor](https://cursor.com)