### PR TITLE
ci: force Pages workflow actions to Node 24

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,6 +19,9 @@ concurrency:
   group: pages
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- force GitHub Pages workflow JavaScript actions to run on Node 24
- prevent future breakage from Node 20 deprecation on GitHub-hosted runners

## Test plan
- [x] Trigger `pages.yml` manually and verify `build` + `deploy` jobs succeed

Made with [Cursor](https://cursor.com)