### PR TITLE
perf: shrink release binary size with build metadata cleanup

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,6 +1,7 @@
 # get the latest git tag like v0.14.0 and remove the prefix v
 latest := `git describe --abbrev=0 --tags | sed 's/v//'`
-ldflags := "-ldflags='-s -w'"
+buildflags := "--trimpath --buildvcs=false"
+ldflags := "-ldflags='-s -w -buildid='"
 
 COLOR_GREEN := "[0;32m"
 COLOR_RED := "[0;31m"
@@ -8,22 +9,22 @@ COLOR_RED := "[0;31m"
 # build lite version (minimal dependencies, smaller binary)
 build-lite:
     mkdir -p build
-    CGO_ENABLED=0 go build {{ldflags}} -o build/g-lite
+    CGO_ENABLED=0 go build {{buildflags}} {{ldflags}} -o build/g-lite
 
 # build full version (all features)  
 build-full:
     mkdir -p build
-    CGO_ENABLED=0 go build {{ldflags}} -tags="fuzzy mounts" -o build/g-full
+    CGO_ENABLED=0 go build {{buildflags}} {{ldflags}} -tags="fuzzy mounts" -o build/g-full
 
 # build with only fuzzy search support
 build-fuzzy:
     mkdir -p build
-    CGO_ENABLED=0 go build {{ldflags}} -tags="fuzzy" -o build/g-fuzzy
+    CGO_ENABLED=0 go build {{buildflags}} {{ldflags}} -tags="fuzzy" -o build/g-fuzzy
 
 # build with only mounts support
 build-mounts:
     mkdir -p build
-    CGO_ENABLED=0 go build {{ldflags}} -tags="mounts" -o build/g-mounts
+    CGO_ENABLED=0 go build {{buildflags}} {{ldflags}} -tags="mounts" -o build/g-mounts
 
 # build binaries for all platforms
 build: 
@@ -31,18 +32,18 @@ build:
     # Linux macOS Windows
     # 386 amd64 arm arm64
     mkdir -p build
-    CGO_ENABLED=0 GOOS=linux GOARCH=386       go build {{ldflags}} -tags="fuzzy mounts" -o build/g-linux-386
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64     go build {{ldflags}} -tags="fuzzy mounts" -o build/g-linux-amd64
-    CGO_ENABLED=0 GOOS=linux GOARCH=arm       go build {{ldflags}} -tags="fuzzy mounts" -o build/g-linux-arm
-    CGO_ENABLED=0 GOOS=linux GOARCH=arm64     go build {{ldflags}} -tags="fuzzy mounts" -o build/g-linux-arm64
-    CGO_ENABLED=0 GOOS=linux GOARCH=loong64   go build {{ldflags}} -tags="fuzzy mounts" -o build/g-linux-loong64
+    CGO_ENABLED=0 GOOS=linux GOARCH=386       go build {{buildflags}} {{ldflags}} -tags="fuzzy mounts" -o build/g-linux-386
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64     go build {{buildflags}} {{ldflags}} -tags="fuzzy mounts" -o build/g-linux-amd64
+    CGO_ENABLED=0 GOOS=linux GOARCH=arm       go build {{buildflags}} {{ldflags}} -tags="fuzzy mounts" -o build/g-linux-arm
+    CGO_ENABLED=0 GOOS=linux GOARCH=arm64     go build {{buildflags}} {{ldflags}} -tags="fuzzy mounts" -o build/g-linux-arm64
+    CGO_ENABLED=0 GOOS=linux GOARCH=loong64   go build {{buildflags}} {{ldflags}} -tags="fuzzy mounts" -o build/g-linux-loong64
 
-    CGO_ENABLED=1 GOOS=darwin GOARCH=amd64  go build {{ldflags}} -tags="fuzzy mounts" -o build/g-darwin-amd64
-    CGO_ENABLED=1 GOOS=darwin GOARCH=arm64  go build {{ldflags}} -tags="fuzzy mounts" -o build/g-darwin-arm64
+    CGO_ENABLED=1 GOOS=darwin GOARCH=amd64  go build {{buildflags}} {{ldflags}} -tags="fuzzy mounts" -o build/g-darwin-amd64
+    CGO_ENABLED=1 GOOS=darwin GOARCH=arm64  go build {{buildflags}} {{ldflags}} -tags="fuzzy mounts" -o build/g-darwin-arm64
 
-    CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build {{ldflags}} -tags="fuzzy mounts" -o build/g-windows-amd64.exe
-    CGO_ENABLED=0 GOOS=windows GOARCH=386   go build {{ldflags}} -tags="fuzzy mounts" -o build/g-windows-386.exe
-    CGO_ENABLED=0 GOOS=windows GOARCH=arm64 go build {{ldflags}} -tags="fuzzy mounts" -o build/g-windows-arm64.exe
+    CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build {{buildflags}} {{ldflags}} -tags="fuzzy mounts" -o build/g-windows-amd64.exe
+    CGO_ENABLED=0 GOOS=windows GOARCH=386   go build {{buildflags}} {{ldflags}} -tags="fuzzy mounts" -o build/g-windows-386.exe
+    CGO_ENABLED=0 GOOS=windows GOARCH=arm64 go build {{buildflags}} {{ldflags}} -tags="fuzzy mounts" -o build/g-windows-arm64.exe
 
     upx --best build/g-linux-386
     upx --best build/g-linux-amd64

--- a/main.go
+++ b/main.go
@@ -1,3 +1,5 @@
+//go:build !doc
+
 package main
 
 import (
@@ -11,9 +13,7 @@ import (
 	"github.com/Equationzhao/g/internal/cli"
 	"github.com/Equationzhao/g/internal/config"
 	debugSetting "github.com/Equationzhao/g/internal/global/debug"
-	"github.com/Equationzhao/g/internal/global/doc"
 	"github.com/Equationzhao/g/internal/util"
-	"github.com/Equationzhao/g/man"
 	ucli "github.com/urfave/cli/v2"
 )
 
@@ -24,19 +24,14 @@ func main() {
 			catchPanic(recover())
 		}
 	}()
-	// when build with tag `doc`, generate md and man file
-	if doc.Enable {
-		man.GenMan()
-	} else {
-		preprocessArgs()
-		err := cli.G.Run(os.Args)
-		if err != nil {
-			if !errors.Is(err, cli.Err4Exit{}) {
-				if cli.ReturnCode == 0 {
-					cli.ReturnCode = 1
-				}
-				_, _ = fmt.Fprintln(os.Stderr, cli.MakeErrorStr(err.Error()))
+	preprocessArgs()
+	err := cli.G.Run(os.Args)
+	if err != nil {
+		if !errors.Is(err, cli.Err4Exit{}) {
+			if cli.ReturnCode == 0 {
+				cli.ReturnCode = 1
 			}
+			_, _ = fmt.Fprintln(os.Stderr, cli.MakeErrorStr(err.Error()))
 		}
 	}
 }

--- a/main_doc.go
+++ b/main_doc.go
@@ -1,0 +1,9 @@
+//go:build doc
+
+package main
+
+import "github.com/Equationzhao/g/man"
+
+func main() {
+	man.GenMan()
+}


### PR DESCRIPTION
## Summary
- shrink release binaries without changing user-visible features
- move doc generation into a doc-only entrypoint so normal builds do not reference it
- use size-oriented Go release flags in the build recipes

## What changed
- split doc-only logic into `main_doc.go` behind `//go:build doc`
- make normal `main.go` `//go:build !doc`
- update release build recipes to use:
  - `--trimpath`
  - `--buildvcs=false`
  - `-ldflags='-s -w -buildid='`

## Validation
- `go test ./...`

## Notes
This PR intentionally keeps the change set small and only includes the doc-entrypoint cleanup plus release build flag improvements.
