### PR TITLE
feat: add --party/--disco rainbow party mode

### DIFF
--- a/internal/cli/display.go
+++ b/internal/cli/display.go
@@ -381,6 +381,13 @@ var displayFlag = []cli.Flag{
 		Category: "DISPLAY",
 	},
 	&cli.BoolFlag{
+		Name:               "party",
+		Aliases:            []string{"disco"},
+		Usage:              "rainbow party mode — each file gets a unique color",
+		DisableDefaultText: true,
+		Category:           "DISPLAY",
+	},
+	&cli.BoolFlag{
 		Name:               "classic",
 		Usage:              "enable classic mode (no colors or icons)",
 		DisableDefaultText: true,

--- a/internal/cli/g.go
+++ b/internal/cli/g.go
@@ -456,6 +456,9 @@ var logic = func(context *cli.Context) error {
 	if _, ok := p.(*display.JsonPrinter); ok {
 		nameToDisplay.SetJson()
 	}
+	if context.Bool("party") {
+		nameToDisplay.SetParty()
+	}
 	git := context.Bool("git")
 	if git {
 		contentFunc = append(contentFunc, gitEnabler.Enable(r))

--- a/internal/content/name.go
+++ b/internal/content/name.go
@@ -422,7 +422,7 @@ func (n *Name) Enable(renderer *render.Renderer) ContentOption {
 
 		name = util.Escape(name)
 
-		if n.Party && color != "" {
+		if n.Party && theme.ColorLevel != theme.None {
 			color = partyColor(int(n.partyIndex.Add(1) - 1))
 		}
 

--- a/internal/content/name.go
+++ b/internal/content/name.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -30,6 +31,8 @@ type Name struct {
 	relativeTo                                                               string
 	Quote                                                                    string
 	QuoteStatus                                                              int8 // >1 always quote || =0 default || <0 never quote
+	Party                                                                    bool
+	partyIndex                                                               atomic.Uint64
 }
 
 func neverQuote(qs int8) bool {
@@ -141,6 +144,16 @@ func (n *Name) UnsetQuote() *Name {
 	return n
 }
 
+func (n *Name) SetParty() *Name {
+	n.Party = true
+	return n
+}
+
+func (n *Name) UnsetParty() *Name {
+	n.Party = false
+	return n
+}
+
 func (n *Name) UnsetIcon() *Name {
 	n.icon = false
 	return n
@@ -209,6 +222,25 @@ Enable
 color + icon + file://quote+filename/relative-name+quote + classify + color-end + dereference + mounts
 color: filetype->filename->fileext->file
 */
+
+func partyColor(index int) string {
+	const goldenAngle = 137.507764 // 180° * (3 - sqrt(5))
+	hue := math.Mod(float64(index)*goldenAngle, 360)
+	r, g, b := theme.HslToRgb(hue, 1.0, 0.5)
+
+	switch theme.ColorLevel {
+	case theme.TrueColor:
+		rgbStr, _ := theme.RGB(r, g, b)
+		return rgbStr
+	case theme.C256:
+		return theme.RGBTo256(r, g, b)
+	case theme.Ascii:
+		return theme.RGBToBasic(r, g, b)
+	default:
+		return ""
+	}
+}
+
 func (n *Name) Enable(renderer *render.Renderer) ContentOption {
 	return func(info *item.FileInfo) (stringContent, funcName string) {
 		name, color, icon, classify, mounts := info.Name(), "", "", "", ""
@@ -389,6 +421,10 @@ func (n *Name) Enable(renderer *render.Renderer) ContentOption {
 		}
 
 		name = util.Escape(name)
+
+		if n.Party && color != "" {
+			color = partyColor(int(n.partyIndex.Add(1) - 1))
+		}
 
 		b := bytebufferpool.Get()
 		defer bytebufferpool.Put(b)


### PR DESCRIPTION
## Summary

- Added `--party` (alias `--disco`) flag that gives each file a unique rainbow color
- Colors are distributed via the golden angle (137.5°) on the HSL hue wheel, ensuring maximum contrast between adjacent files
- Automatically adapts to terminal color level: TrueColor / 256-color / 16-color
- Only overrides the filename color — permissions, sizes, timestamps, and other metadata keep their theme colors

## Demo

```bash
g --party          # list mode, rainbow filenames
g --party --long   # long format
g --party --tree   # tree view
g --disco          # alias works too
```

## Files changed

- `internal/content/name.go` — party mode core logic: golden angle color generation + Name fields/methods
- `internal/cli/display.go` — `--party`/`--disco` flag definition
- `internal/cli/g.go` — flag wiring

## Test plan

- [x] `--party` produces rainbow filename colors in default mode
- [x] `--party --long` only filenames change color, other columns keep theme colors
- [x] `--party --tree` tree view works correctly
- [x] `--disco` alias works
- [x] `--party --no-color` does not show colors
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/content/ ./internal/cli/ ./internal/theme/` all PASS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only coloring for entry names; no changes to I/O, auth, or data handling.
> 
> **Overview**
> Adds **`--party`** (alias **`--disco`**) as a DISPLAY flag and wires it in the main listing path so **`Name.SetParty()`** runs when the flag is set.
> 
> When party mode is on and colors are not disabled, each entry’s **filename color** is replaced by a distinct hue from a **golden-angle** sequence on the HSL wheel, emitted as TrueColor, 256-color, or 16-color ANSI via existing **`theme`** helpers. Icons, classify suffixes, symlink targets, mounts, and other columns still use normal theme styling.
> 
> **`--no-color`** / **`theme.ColorLevel == None`** leaves party coloring inactive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cea7c0982e404fa1ac87f38beb33b8ae378b0f62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->